### PR TITLE
extension distribution: remove global extensions

### DIFF
--- a/extension_distribution.md
+++ b/extension_distribution.md
@@ -319,7 +319,7 @@ But I've punted on the specifics of how this should work.
 
 ### Concurrency
 
-Extension repos are installed under `~/.tilt-dev`.
+Extension repos are installed under `$XDG_DATA_HOME/tilt-dev` (default to `~/.local/share/tilt-dev`).
 
 If you have two tilt instances running at the same time, there's a possibility
 they will step on each other's state.
@@ -342,5 +342,4 @@ code into the project directory instead of the global directory.
 We would need some way to unify this with the existing `tilt_modules` directory
 (for `load('ext://...')`). But I don't think it makes sense to unify them at
 this stage.  The extension API model is still evolving.
-
 


### PR DESCRIPTION
Hello @ellenkorbes, @milas, @landism,

Please review the following commits I made in branch nicks/rescope:

1e1aa4cb32b4c24c3aa841463e3e662fd6688f50 (2021-08-10 18:29:40 -0400)
extension distribution: remove global extensions

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics